### PR TITLE
Help from docstrings, fix defaults formatting

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Typer
+title: Typer-Doc
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
@@ -15,7 +15,7 @@ identifiers:
 repository-code: 'https://github.com/fastapi/typer'
 url: 'https://typer.tiangolo.com'
 abstract: >-
-  Typer, build great CLIs. Easy to code. Based on Python type hints.
+  Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings.
 keywords:
   - typer
   - click

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 </p>
 <p align="center">
-    <em>Typer, build great CLIs. Easy to code. Based on Python type hints.</em>
+    <em>Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings.</em>
 </p>
 <p align="center">
-<a href="https://github.com/fastapi/typer/actions?query=workflow%3ATest" target="_blank">
-    <img src="https://github.com/fastapi/typer/workflows/Test/badge.svg" alt="Test">
+<a href="https://github.com/buhanec/typer-doc/actions?query=workflow%3ATest" target="_blank">
+    <img src="https://github.com/buhanec/typer-doc/workflows/Test/badge.svg" alt="Test">
 </a>
-<a href="https://github.com/fastapi/typer/actions?query=workflow%3APublish" target="_blank">
-    <img src="https://github.com/fastapi/typer/workflows/Publish/badge.svg" alt="Publish">
+<a href="https://github.com/buhanec/typer-doc/actions?query=workflow%3APublish" target="_blank">
+    <img src="https://github.com/buhanec/typer-doc/workflows/Publish/badge.svg" alt="Publish">
 </a>
 <a href="https://coverage-badge.samuelcolvin.workers.dev/redirect/fastapi/typer" target="_blank">
     <img src="https://coverage-badge.samuelcolvin.workers.dev/fastapi/typer.svg" alt="Coverage">
@@ -23,11 +23,11 @@
 
 **Documentation**: <a href="https://typer.tiangolo.com" target="_blank">https://typer.tiangolo.com</a>
 
-**Source Code**: <a href="https://github.com/fastapi/typer" target="_blank">https://github.com/fastapi/typer</a>
+**Source Code**: <a href="https://github.com/buhanec/typer-doc" target="_blank">https://github.com/buhanec/typer-doc</a>, with minimal patching on top of <a href="https://github.com/fastapi/typer" target="_blank">https://github.com/fastapi/typer</a>
 
 ---
 
-Typer is a library for building <abbr title="command line interface, programs executed from a terminal">CLI</abbr> applications that users will **love using** and developers will **love creating**. Based on Python type hints.
+Typer is a library for building <abbr title="command line interface, programs executed from a terminal">CLI</abbr> applications that users will **love using** and developers will **love creating**. Based on Python type hints and docstrings.
 
 It's also a command line tool to run scripts, automatically converting them to CLI applications.
 
@@ -40,6 +40,14 @@ The key features are:
 * **Grow large**: Grow in complexity as much as you want, create arbitrarily complex trees of commands and groups of subcommands, with options and arguments.
 * **Run scripts**: Typer includes a `typer` command/program that you can use to run scripts, automatically converting them to CLIs, even if they don't use Typer internally.
 
+---
+
+The patches applied by the fork include:
+
+* **Param help from docstrings**: Parse param help string from docstrings.
+* **Fix plain defaults formatting**: Remove errant backslash when not using `rich` formatting 
+* **Test running**: Allow running "Linux" tests on macOS, correctly detect bash being present 
+
 ## FastAPI of CLIs
 
 **Typer** is <a href="https://fastapi.tiangolo.com" class="external-link" target="_blank">FastAPI</a>'s little sibling, it's the FastAPI of CLIs.
@@ -51,9 +59,9 @@ Create and activate a <a href="https://typer.tiangolo.com/virtual-environments/"
 <div class="termy">
 
 ```console
-$ pip install typer
+$ pip install typer-doc
 ---> 100%
-Successfully installed typer rich shellingham
+Successfully installed typer rich shellingham docstring-parser
 ```
 
 </div>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@ First, you might want to see the basic ways to [help Typer and get help](help-ty
 
 ## Developing
 
-If you already cloned the <a href="https://github.com/fastapi/typer" class="external-link" target="_blank">typer repository</a> and you want to deep dive in the code, here are some guidelines to set up your environment.
+If you already cloned the <a href="https://github.com/buhanec/typer-doc" class="external-link" target="_blank">typer repository</a> and you want to deep dive in the code, here are some guidelines to set up your environment.
 
 ### Virtual Environment
 

--- a/docs/img/github-social-preview.svg
+++ b/docs/img/github-social-preview.svg
@@ -168,5 +168,5 @@
        x="169.84227"
        y="125.57798"
        style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Roboto;-inkscape-font-specification:'Roboto Italic';text-align:center;text-anchor:middle;stroke-width:0.264583"
-       id="tspan855-5">Build great CLIs. Easy to code. Based on Python type hints.</tspan></text>
+       id="tspan855-5">Build great CLIs. Easy to code. Based on Python type hints and docstrings.</tspan></text>
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 <!-- /only-mkdocs -->
 </p>
 <p align="center">
-    <em>Typer, build great CLIs. Easy to code. Based on Python type hints.</em>
+    <em>Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings.</em>
 </p>
 <p align="center">
 <a href="https://github.com/fastapi/typer/actions?query=workflow%3ATest" target="_blank">
@@ -33,7 +33,7 @@
 
 ---
 
-Typer is a library for building <abbr title="command line interface, programs executed from a terminal">CLI</abbr> applications that users will **love using** and developers will **love creating**. Based on Python type hints.
+Typer is a library for building <abbr title="command line interface, programs executed from a terminal">CLI</abbr> applications that users will **love using** and developers will **love creating**. Based on Python type hints and docstrings.
 
 It's also a command line tool to run scripts, automatically converting them to CLI applications.
 

--- a/docs/tutorial/commands/help.md
+++ b/docs/tutorial/commands/help.md
@@ -6,6 +6,10 @@ And the `typer.Typer()` application receives a parameter `help` that you can pas
 
 {* docs_src/commands/help/tutorial001_an.py hl[4,9:11,22,26:30,43,47:51,60:62] *}
 
+Alternatively, a best-effort attempt is made to parse docstrings and infer the help string:
+
+{* docs_src/commands/help/tutorial001_doc.py *}
+
 Check it:
 
 <div class="termy">

--- a/docs_src/arguments/help/tutorial001_doc.py
+++ b/docs_src/arguments/help/tutorial001_doc.py
@@ -1,0 +1,13 @@
+import typer
+
+
+def main(name: str):
+    """Greet user.
+
+    :param name: The name of the user to greet
+    """
+    print(f"Hello {name}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 INHERIT: ./mkdocs.maybe-insiders.yml
 site_name: Typer
-site_description: Typer, build great CLIs. Easy to code. Based on Python type hints.
+site_description: Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings.
 site_url: https://typer.tiangolo.com/
 
 theme:
@@ -53,8 +53,8 @@ theme:
   logo: img/icon.svg
   favicon: img/favicon.png
   language: en
-repo_name: fastapi/typer
-repo_url: https://github.com/fastapi/typer
+repo_name: buhanec/typer-doc
+repo_url: https://github.com/buhanec/typer-doc
 plugins:
   # Material for MkDocs
   search:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["pdm-backend"]
 build-backend = "pdm.backend"
 
 [project]
-name = "typer"
+name = "typer-doc"
 dynamic = ["version"]
-description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings."
 authors = [
     {name = "Sebastián Ramírez", email = "tiangolo@gmail.com"},
 ]
@@ -39,10 +39,10 @@ dependencies = [
 ]
 readme = "README.md"
 [project.urls]
-Homepage = "https://github.com/fastapi/typer"
+Homepage = "https://github.com/buhanec/typer-doc"
 Documentation = "https://typer.tiangolo.com"
-Repository = "https://github.com/fastapi/typer"
-Issues = "https://github.com/fastapi/typer/issues"
+Repository = "https://github.com/buhanec/typer-doc"
+Issues = "https://github.com/buhanec/typer-doc/issues"
 Changelog = "https://typer.tiangolo.com/release-notes/"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ Changelog = "https://typer.tiangolo.com/release-notes/"
 standard = [
     "shellingham >=1.3.0",
     "rich >=10.11.0",
+    "docstring-parser >= 0.16",
 ]
 
 [tool.pdm]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -10,3 +10,5 @@ ruff ==0.11.13
 # Needed explicitly by typer-slim
 rich >=10.11.0
 shellingham >=1.3.0
+# Needed for docstring parsing tests
+docstring-parser >= 0.16

--- a/tests/test_tutorial/test_arguments/test_default/test_tutorial001.py
+++ b/tests/test_tutorial/test_arguments/test_default/test_tutorial001.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
@@ -8,11 +9,15 @@ from docs_src.arguments.default import tutorial001 as mod
 
 runner = CliRunner()
 
-app = typer.Typer()
-app.command()(mod.main)
+
+@pytest.fixture(scope="module", params=["rich", "markdown", None])
+def app(request: pytest.FixtureRequest):
+    app = typer.Typer(rich_markup_mode=request.param)
+    app.command()(mod.main)
+    yield app
 
 
-def test_help():
+def test_help(app):
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
@@ -20,19 +25,24 @@ def test_help():
     assert "[default: Wade Wilson]" in result.output
 
 
-def test_call_no_arg():
+def test_no_escaped_help(app):
+    result = runner.invoke(app, ["--help"])
+    assert not "\\[default: Wade Wilson]" in result.output
+
+
+def test_call_no_arg(app):
     result = runner.invoke(app)
     assert result.exit_code == 0
     assert "Hello Wade Wilson" in result.output
 
 
-def test_call_arg():
+def test_call_arg(app):
     result = runner.invoke(app, ["Camila"])
     assert result.exit_code == 0
     assert "Hello Camila" in result.output
 
 
-def test_script():
+def test_script(app):
     result = subprocess.run(
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,

--- a/tests/test_tutorial/test_arguments/test_default/test_tutorial001_an.py
+++ b/tests/test_tutorial/test_arguments/test_default/test_tutorial001_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
@@ -8,11 +9,15 @@ from docs_src.arguments.default import tutorial001_an as mod
 
 runner = CliRunner()
 
-app = typer.Typer()
-app.command()(mod.main)
+
+@pytest.fixture(scope="module", params=["rich", "markdown", None])
+def app(request: pytest.FixtureRequest):
+    app = typer.Typer(rich_markup_mode=request.param)
+    app.command()(mod.main)
+    yield app
 
 
-def test_help():
+def test_help(app):
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
@@ -20,19 +25,19 @@ def test_help():
     assert "[default: Wade Wilson]" in result.output
 
 
-def test_call_no_arg():
+def test_call_no_arg(app):
     result = runner.invoke(app)
     assert result.exit_code == 0, result.output
     assert "Hello Wade Wilson" in result.output
 
 
-def test_call_arg():
+def test_call_arg(app):
     result = runner.invoke(app, ["Camila"])
     assert result.exit_code == 0
     assert "Hello Camila" in result.output
 
 
-def test_script():
+def test_script(app):
     result = subprocess.run(
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,

--- a/tests/test_tutorial/test_arguments/test_default/test_tutorial002_an.py
+++ b/tests/test_tutorial/test_arguments/test_default/test_tutorial002_an.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+import pytest
 import typer
 from typer.testing import CliRunner
 
@@ -8,11 +9,15 @@ from docs_src.arguments.default import tutorial002_an as mod
 
 runner = CliRunner()
 
-app = typer.Typer()
-app.command()(mod.main)
+
+@pytest.fixture(scope="module", params=["rich", "markdown", None])
+def app(request: pytest.FixtureRequest):
+    app = typer.Typer(rich_markup_mode=request.param)
+    app.command()(mod.main)
+    yield app
 
 
-def test_help():
+def test_help(app):
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "[OPTIONS] [NAME]" in result.output
@@ -20,7 +25,7 @@ def test_help():
     assert "[default: (dynamic)]" in result.output
 
 
-def test_call_no_arg():
+def test_call_no_arg(app):
     greetings = ["Hello Deadpool", "Hello Rick", "Hello Morty", "Hello Hiro"]
     for _i in range(3):
         result = runner.invoke(app)
@@ -28,13 +33,13 @@ def test_call_no_arg():
         assert any(greet in result.output for greet in greetings)
 
 
-def test_call_arg():
+def test_call_arg(app):
     result = runner.invoke(app, ["Camila"])
     assert result.exit_code == 0
     assert "Hello Camila" in result.output
 
 
-def test_script():
+def test_script(app):
     result = subprocess.run(
         [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
         capture_output=True,

--- a/tests/test_tutorial/test_arguments/test_help/test_tutorial001_doc.py
+++ b/tests/test_tutorial/test_arguments/test_help/test_tutorial001_doc.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+
+import typer
+import typer.core
+from typer.testing import CliRunner
+
+from docs_src.arguments.help import tutorial001_doc as mod
+
+runner = CliRunner()
+
+app = typer.Typer()
+app.command()(mod.main)
+
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "[OPTIONS] NAME" in result.output
+    assert ":param:" not in result.output
+    assert "Arguments" in result.output
+    assert "NAME" in result.output
+    assert "The name of the user to greet" in result.output
+    assert "[required]" in result.output
+
+
+def test_help_no_rich():
+    rich = typer.core.rich
+    typer.core.rich = None
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "[OPTIONS] NAME" in result.output
+    assert ":param:" not in result.output
+    assert "Arguments" in result.output
+    assert "NAME" in result.output
+    assert "The name of the user to greet" in result.output
+    assert "[required]" in result.output
+    typer.core.rich = rich
+
+
+def test_call_arg():
+    result = runner.invoke(app, ["Camila"])
+    assert result.exit_code == 0
+    assert "Hello Camila" in result.output
+
+
+def test_script():
+    result = subprocess.run(
+        [sys.executable, "-m", "coverage", "run", mod.__file__, "--help"],
+        capture_output=True,
+        encoding="utf-8",
+    )
+    assert "Usage" in result.stdout

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,7 +20,7 @@ needs_py310 = pytest.mark.skipif(
 )
 
 needs_linux = pytest.mark.skipif(
-    not sys.platform.startswith("linux"), reason="Test requires Linux"
+    not sys.platform.startswith(("linux", "darwin")), reason="Test requires Linux/macOS"
 )
 
 needs_bash = pytest.mark.skipif(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 from os import getenv
 
@@ -24,7 +25,7 @@ needs_linux = pytest.mark.skipif(
 )
 
 needs_bash = pytest.mark.skipif(
-    not shellingham or not shell or "bash" not in shell, reason="Test requires Bash"
+    shutil.which("bash") is not None, reason="Test requires Bash"
 )
 
 requires_completion_permission = pytest.mark.skipif(

--- a/typer-cli/README.md
+++ b/typer-cli/README.md
@@ -2,7 +2,7 @@
   <a href="https://typer.tiangolo.com"><img src="https://typer.tiangolo.com/img/logo-margin/logo-margin-vector.svg" alt="Typer"></a>
 </p>
 <p align="center">
-    <em>Typer, build great CLIs. Easy to code. Based on Python type hints.</em>
+    <em>Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings.</em>
 </p>
 <p align="center">
 <a href="https://github.com/fastapi/typer/actions?query=workflow%3ATest" target="_blank">
@@ -22,11 +22,11 @@
 
 **Documentation**: <a href="https://typer.tiangolo.com" target="_blank">https://typer.tiangolo.com/tutorial/typer-command/</a>
 
-**Source Code**: <a href="https://github.com/fastapi/typer" target="_blank">https://github.com/fastapi/typer</a>
+**Source Code**: <a href="https://github.com/buhanec/typer-doc" target="_blank">https://github.com/buhanec/typer-doc</a>
 
 ---
 
-Typer is a library for building <abbr title="command line interface, programs executed from a terminal">CLI</abbr> applications that users will **love using** and developers will **love creating**. Based on Python type hints.
+Typer is a library for building <abbr title="command line interface, programs executed from a terminal">CLI</abbr> applications that users will **love using** and developers will **love creating**. Based on Python type hints and docstrings.
 
 ## Typer CLI
 

--- a/typer/__init__.py
+++ b/typer/__init__.py
@@ -1,4 +1,4 @@
-"""Typer, build great CLIs. Easy to code. Based on Python type hints."""
+"""Typer, build great CLIs. Easy to code. Based on Python type hints and docstrings."""
 
 __version__ = "0.16.0"
 

--- a/typer/cli.py
+++ b/typer/cli.py
@@ -222,7 +222,10 @@ def get_docs_for_click(
     args = []
     opts = []
     for param in obj.get_params(ctx):
-        rv = param.get_help_record(ctx)
+        if isinstance(param, (typer.core.TyperArgument, typer.core.TyperOption)):
+            rv = param.get_help_record(ctx, docs=True)
+        else:
+            rv = param.get_help_record(ctx)
         if rv is not None:
             if param.param_type_name == "argument":
                 args.append(rv)

--- a/typer/core.py
+++ b/typer/core.py
@@ -324,7 +324,7 @@ class TyperArgument(click.core.Argument):
     ) -> Optional[Union[Any, Callable[[], Any]]]:
         return _extract_default_help_str(self, ctx=ctx)
 
-    def get_help_record(self, ctx: click.Context) -> Optional[Tuple[str, str]]:
+    def get_help_record(self, ctx: click.Context, docs: bool = False) -> Optional[Tuple[str, str]]:
         # Modified version of click.core.Option.get_help_record()
         # to support Arguments
         if self.hidden:
@@ -368,7 +368,7 @@ class TyperArgument(click.core.Argument):
         if extra:
             extra_str = "; ".join(extra)
             extra_str = f"[{extra_str}]"
-            if rich is not None:
+            if rich is not None and docs:
                 # This is needed for when we want to export to HTML
                 extra_str = rich.markup.escape(extra_str).strip()
 
@@ -497,7 +497,7 @@ class TyperOption(click.core.Option):
         # Click < 8.2
         return super().make_metavar()  # type: ignore[call-arg]
 
-    def get_help_record(self, ctx: click.Context) -> Optional[Tuple[str, str]]:
+    def get_help_record(self, ctx: click.Context, docs: bool = False) -> Optional[Tuple[str, str]]:
         # Duplicate all of Click's logic only to modify a single line, to allow boolean
         # flags with only names for False values as it's currently supported by Typer
         # Ref: https://typer.tiangolo.com/tutorial/parameter-types/bool/#only-names-for-false
@@ -579,7 +579,7 @@ class TyperOption(click.core.Option):
         if extra:
             extra_str = "; ".join(extra)
             extra_str = f"[{extra_str}]"
-            if rich is not None:
+            if rich is not None and docs:
                 # This is needed for when we want to export to HTML
                 extra_str = rich.markup.escape(extra_str).strip()
 


### PR DESCRIPTION
Patches for a couple things that annoy me:

* **Param help from docstrings**: Parse param help string from docstrings.
* **Fix plain defaults formatting**: Remove errant backslash when not using `rich` formatting 
* **Test running**: Allow running "Linux" tests on macOS, correctly detect bash being present 
